### PR TITLE
Update README to clarify meson workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Izumi is an instruction pipeline visualizer for Onikiri2-Kanata format based on 
 
 ## Requierments
 
-- ncurses
-- meson (build only)
-- ninja (build only, can be replaced by other meson backends)
+- `ncurses`
+- `meson` (build only) *[version >=1.2.0]*
+- `ninja` (build only, can be replaced by other meson backends)
 
 ## Building (and installing)
 
@@ -32,6 +32,8 @@ cd build
 meson compile
 meson install
 ```
+> [!IMPORTANT]  
+> meson needs to be available as root for `meson install`
 
 But, if the classic `make` sequence is hard-wired in your brain, you can:
 


### PR DESCRIPTION
Trying to compile and install Izumi using `meson` (first time using meson for me) found some friction:

- `meson` is available at `apt` and has an ancient enough version to crash the building process.
  - To at least warn the users, I added the minimum required version of `meson` on the README
- Installing crashes if you run `meson install` and have `meson` installed only at user-level.
  - I added a warning about that